### PR TITLE
Move over IIngredient implementation from TFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Airlock
 
 ***Cleanroom's own, non-overrated, API.***
+
+Code sourced from: TerraFirmaCraft, GregTechCEu, CodeChickenLib

--- a/src/api/java/io/github/cleanroommc/airlock/api/ingredient/IIngredient.java
+++ b/src/api/java/io/github/cleanroommc/airlock/api/ingredient/IIngredient.java
@@ -1,0 +1,133 @@
+package io.github.cleanroommc.airlock.api.ingredient;
+
+import io.github.cleanroommc.airlock.api.ingredient.impl.IngredientFluidStack;
+import io.github.cleanroommc.airlock.api.ingredient.impl.IngredientItemStack;
+import io.github.cleanroommc.airlock.api.ingredient.impl.IngredientOreDict;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import javax.annotation.Nonnull;
+import java.util.function.Predicate;
+
+/**
+ * This is an ingredient wrapper for various types
+ * It includes static constructors for both item stack and fluid stack ingredients
+ *
+ * @param <T> the type of ingredient (i.e. ItemStack, FluidStack, etc.)
+ * @author AlcatrazEscapee
+ */
+public interface IIngredient<T> extends Predicate<T>
+{
+    IIngredient<?> EMPTY = input -> false;
+    IIngredient<?> ANY = input -> true;
+
+    @SuppressWarnings("unchecked")
+    static <P> IIngredient<P> empty()
+    {
+        return (IIngredient<P>) EMPTY;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <P> IIngredient<P> any()
+    {
+        return (IIngredient<P>) ANY;
+    }
+
+    static IIngredient<ItemStack> of(@Nonnull Block predicateBlock)
+    {
+        return new IngredientItemStack(new ItemStack(predicateBlock, 1, OreDictionary.WILDCARD_VALUE));
+    }
+
+    static IIngredient<ItemStack> of(@Nonnull Item predicateItem)
+    {
+        return new IngredientItemStack(new ItemStack(predicateItem, 1, OreDictionary.WILDCARD_VALUE));
+    }
+
+    static IIngredient<ItemStack> of(@Nonnull Item predicateItem, int amount)
+    {
+        return new IngredientItemStack(new ItemStack(predicateItem, amount, OreDictionary.WILDCARD_VALUE));
+    }
+
+    static IIngredient<ItemStack> of(@Nonnull ItemStack predicateStack)
+    {
+        return new IngredientItemStack(predicateStack);
+    }
+
+    static IIngredient<ItemStack> of(@Nonnull String oreName)
+    {
+        return new IngredientOreDict(oreName);
+    }
+
+    static IIngredient<ItemStack> of(@Nonnull String oreName, int amount)
+    {
+        return new IngredientOreDict(oreName, amount);
+    }
+
+    static IIngredient<FluidStack> of(@Nonnull FluidStack predicateStack)
+    {
+        return new IngredientFluidStack(predicateStack);
+    }
+
+    static IIngredient<FluidStack> of(@Nonnull Fluid fluid, int amount)
+    {
+        return new IngredientFluidStack(fluid, amount);
+    }
+
+    /**
+     * This is used by JEI-CT hooks, return a valid list of inputs for this IIngredient
+     *
+     * @return NonNullList containing valid ingredients(fluidstack/itemstack) for this IIngredient
+     */
+    default NonNullList<T> getValidIngredients()
+    {
+        return NonNullList.create();
+    }
+
+    /**
+     * This is used by recipes to test if the ingredient matches the input
+     *
+     * @param input the input supplied to the recipe
+     * @return true if the ingredient matches the input
+     */
+    @Override
+    boolean test(T input);
+
+    /**
+     * This is used by recipes to test if an input is valid, but necessarily high enough quantity
+     * i.e. used to check if an item is valid for a slot, not if the recipe will complete.
+     *
+     * @param input the input supplied to the recipe
+     * @return true if the ingredient matches the input, ignoring the amount of input
+     */
+    default boolean testIgnoreCount(T input)
+    {
+        return test(input);
+    }
+
+    /**
+     * Consume one recipe's worth of input
+     * Depending on the input type, this may modify input and return it, or create a new output
+     *
+     * @param input the input supplied to the recipe
+     * @return the result after modification.
+     */
+    default T consume(T input)
+    {
+        return input;
+    }
+
+    /**
+     * Get the amount represented by this ingredient
+     *
+     * @return the amount
+     */
+    default int getAmount()
+    {
+        return 1;
+    }
+}

--- a/src/api/java/io/github/cleanroommc/airlock/api/ingredient/impl/IngredientFluidStack.java
+++ b/src/api/java/io/github/cleanroommc/airlock/api/ingredient/impl/IngredientFluidStack.java
@@ -1,0 +1,63 @@
+package io.github.cleanroommc.airlock.api.ingredient.impl;
+
+import io.github.cleanroommc.airlock.api.ingredient.IIngredient;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class IngredientFluidStack implements IIngredient<FluidStack>
+{
+    private final FluidStack inputFluid;
+
+    public IngredientFluidStack(@Nonnull Fluid fluid, int amount)
+    {
+        this(new FluidStack(fluid, amount));
+    }
+
+    public IngredientFluidStack(@Nonnull FluidStack inputFluid)
+    {
+        this.inputFluid = inputFluid;
+    }
+
+    @Override
+    public NonNullList<FluidStack> getValidIngredients()
+    {
+        return NonNullList.withSize(1, inputFluid.copy());
+    }
+
+    @Override
+    public boolean test(FluidStack fluidStack)
+    {
+        return testIgnoreCount(fluidStack) && fluidStack.amount >= this.inputFluid.amount;
+    }
+
+    @Override
+    public boolean testIgnoreCount(FluidStack fluidStack)
+    {
+        return fluidStack != null && fluidStack.getFluid() != null && fluidStack.getFluid() == this.inputFluid.getFluid();
+    }
+
+    @Override
+    @Nullable
+    public FluidStack consume(FluidStack input)
+    {
+        if (input.amount > inputFluid.amount)
+        {
+            return new FluidStack(input.getFluid(), input.amount - inputFluid.amount);
+        }
+        return null;
+    }
+
+    @Override
+    public int getAmount()
+    {
+        if (inputFluid != null)
+        {
+            return inputFluid.amount;
+        }
+        return 0;
+    }
+}

--- a/src/api/java/io/github/cleanroommc/airlock/api/ingredient/impl/IngredientItemStack.java
+++ b/src/api/java/io/github/cleanroommc/airlock/api/ingredient/impl/IngredientItemStack.java
@@ -1,0 +1,57 @@
+package io.github.cleanroommc.airlock.api.ingredient.impl;
+
+import io.github.cleanroommc.airlock.api.ingredient.IIngredient;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.oredict.OreDictionary;
+
+import javax.annotation.Nonnull;
+
+public class IngredientItemStack implements IIngredient<ItemStack>
+{
+    private final ItemStack inputStack;
+
+    public IngredientItemStack(@Nonnull ItemStack inputStack)
+    {
+        this.inputStack = inputStack;
+    }
+
+    @Override
+    public NonNullList<ItemStack> getValidIngredients()
+    {
+        return NonNullList.withSize(1, inputStack.copy());
+    }
+
+    @Override
+    public boolean test(ItemStack stack)
+    {
+        return testIgnoreCount(stack) && stack.getCount() >= inputStack.getCount();
+    }
+
+    @Override
+    public boolean testIgnoreCount(ItemStack stack)
+    {
+        if (stack != null && (!stack.isEmpty() || inputStack.isEmpty()))
+        {
+            if (inputStack.getItem() == stack.getItem())
+            {
+                return inputStack.getMetadata() == OreDictionary.WILDCARD_VALUE || inputStack.getMetadata() == stack.getMetadata();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack consume(ItemStack input)
+    {
+        input.shrink(inputStack.getCount());
+        return input;
+    }
+
+    @Override
+    public int getAmount()
+    {
+        return inputStack.getCount();
+    }
+}

--- a/src/api/java/io/github/cleanroommc/airlock/api/ingredient/impl/IngredientOreDict.java
+++ b/src/api/java/io/github/cleanroommc/airlock/api/ingredient/impl/IngredientOreDict.java
@@ -1,0 +1,63 @@
+package io.github.cleanroommc.airlock.api.ingredient.impl;
+
+import io.github.cleanroommc.airlock.api.ingredient.IIngredient;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.oredict.OreDictionary;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+
+public class IngredientOreDict implements IIngredient<ItemStack> {
+    private final String oreName;
+    private final int amount;
+
+    public IngredientOreDict(@Nonnull String oreName) {
+        this(oreName, 1);
+    }
+
+    public IngredientOreDict(@Nonnull String oreName, int amount) {
+        this.oreName = oreName;
+        this.amount = amount;
+    }
+
+    @Override
+    public NonNullList<ItemStack> getValidIngredients() {
+        NonNullList<ItemStack> output = NonNullList.create();
+        for (ItemStack out : OreDictionary.getOres(oreName)) {
+            ItemStack addToList = out.copy(); // Don't tamper with forge's ore dictionary list
+            addToList.setCount(amount);
+            output.add(addToList);
+        }
+        return output;
+    }
+
+    @Override
+    public boolean test(ItemStack stack) {
+        return testIgnoreCount(stack) && stack.getCount() >= amount;
+    }
+
+    @Override
+    public boolean testIgnoreCount(ItemStack stack) {
+        return stack != null && !stack.isEmpty() &&
+                Arrays.asList(Arrays.stream(OreDictionary.getOreIDs(stack)).boxed().toArray(Integer[]::new))
+                .contains(OreDictionary.getOreID(oreName)); // See if the item has the oredict
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack consume(ItemStack input) {
+        input.shrink(amount);
+        return input;
+    }
+
+    @Override
+    public int getAmount() {
+        return amount;
+    }
+
+    @Nonnull
+    public String getOreName() {
+        return oreName;
+    }
+}


### PR DESCRIPTION
Simply adds IIngredient, IngredientItemStack, IngredientFluidStack, and IngredientOreDict, from TFC.
Also adds a statement of credit to the README before drama occurs.